### PR TITLE
Fix InGameMenu class reference for Discord button

### DIFF
--- a/LoadingScreen/Scripts/5_Mission/gui/InGameMenu_Discord.c
+++ b/LoadingScreen/Scripts/5_Mission/gui/InGameMenu_Discord.c
@@ -55,7 +55,7 @@ static ButtonWidget FindAnyButton(Widget root)
     return null;
 }
 
-modded class IngameMenu extends UIScriptedMenu
+modded class InGameMenu extends UIScriptedMenu
 {
     protected ButtonWidget m_DiscordBtn;
 


### PR DESCRIPTION
## Summary
- use correct `InGameMenu` class name to hook Discord button into in-game menu

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a128da5b48326b77cdff8abba9048